### PR TITLE
Date conditions

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,7 +3,6 @@ class DocumentsController < ApplicationController
   def show
     @document = Document.find(params[:id])
     @info = Info.find(params[:info_id])
-binding.pry
     @days_worked = (@document.old_end_date - @document.verify_start_date).to_i - @document.latency
     if @document.start_unemployment_at
       unemployment_calc(@document)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,11 +3,15 @@ class DocumentsController < ApplicationController
   def show
     @document = Document.find(params[:id])
     @info = Info.find(params[:info_id])
+binding.pry
+    @days_worked = (@document.old_end_date - @document.verify_start_date).to_i - @document.latency
     if @document.start_unemployment_at
-      @unemployment_days_paid = (@document.start_date - @document.start_unemployment_at).to_i
-      @unemployment_days_remaining = @document.info.days_unemployment - @unemployment_days_paid
+      unemployment_calc(@document)
+    elsif @document.info.jobs.present?
+      @days_worked += @document.days_worked_other_jobs_calc
+      @document.recalculate_jobs
     end
-    @duration = (@document.end_date - @document.start_date).to_i/30
+    @duration = (@document.end_date - @document.start_date)/30
     respond_to do |format|
       format.html
       format.pdf do
@@ -39,11 +43,18 @@ class DocumentsController < ApplicationController
       render(:new)
     end
   end
-
+  
   private
+
+  def unemployment_calc
+    @unemployment_days_paid = (start_date - start_unemployment_at).to_i
+    @unemployment_days_remaining = @info.days_unemployment - @unemployment_days_paid
+  end
+
   def params_document
     params.require(:document).permit(:first_name, :last_name,
     :company, :work, :work_type, :start_date, :end_date, :old_work,
     :old_company, :old_start_date, :old_end_date, :start_unemployment_at)
   end
+
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -17,6 +17,7 @@ class Document < ApplicationRecord
   validate :end_date_cannot_be_too_big
   validate :start_unemployment_at_cannot_be_after_start_date
   validate :start_unemployment_at_cannot_be_before_old_end_date
+  validate :jobs_validation
   belongs_to :info
 
   def start_date_cannot_be_in_the_future
@@ -91,6 +92,17 @@ class Document < ApplicationRecord
       (Date.today - end_date).to_i
     else 
       0
+    end
+  end
+
+  def jobs_validation
+    if info.jobs.present?
+      sort_jobs = info.jobs.order(:start_at)
+      sort_jobs.to_a.each_with_index do |job, index|
+        if (index < sort_jobs.length - 1 && job.end_at > sort_jobs[index + 1].start_at) || job.end_at > old_start_date
+          errors.add(:old_end_date, "Il y a un problème au niveau des dates saisies pour les différents jobs.")
+        end
+      end
     end
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -5,6 +5,7 @@ class Job < ApplicationRecord
   validates :start_at, presence: true
   validates :end_at, presence: true
   validate :start_at_cannot_be_in_the_future
+  validate :end_at_cannot_be_before_start_at
   
   def start_at_cannot_be_in_the_future
     if start_at.present? && start_at > Date.today 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -43,4 +43,3 @@
     <%= render 'documents/modal_job' %>
   </div>
 </div>
-<% console %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -43,3 +43,4 @@
     <%= render 'documents/modal_job' %>
   </div>
 </div>
+<% console %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,8 +1,9 @@
 <div class="container">
   <div class="document-container">
-    <div class="title">
+    <div class="title text-center">
       <h1>Dossier Retour V.I (Volontariat International)</h1>
       <h3>- Demande de réouverture des droits au chômage -</h3>
+      <h5><%= "#{@document.first_name} #{@document.last_name}" %></h5>
     </div>
 
     <br>
@@ -10,7 +11,8 @@
     <div>
       Être Volontaire International (V.I), c’est partir pour une mission professionnelle à l'étranger tout en bénéficiant d’un statut public protecteur. Le V.I est placé sous la tutelle de l’Ambassade de France et est défini dans <b><a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000021954325&categorieLien=id#:~:text=%2DI.,d'une%20personne%20morale%20agr%C3%A9%C3%A9e" target="_blank">la loi n° 2010-241 du 10 mars 2010 </a></b>.
       <br>
-      De 6 à 24 mois, les missions s’effectuent :
+      <br>
+      <div class="mb-1">De 6 à 24 mois, les missions s’effectuent :</div>
       <ul>
         <li>en entreprise, </li>
         <li>au sein d’une structure française, publique ou para-publique, relevant du Ministère des Affaires Etrangères et du Développement International ou du Ministère de l’Economie,</li>
@@ -19,29 +21,35 @@
       </ul>
       Le Volontariat International n'est pas du bénévolat. Les V.I perçoivent mensuellement une indemnité forfaitaire variable suivant le pays d’affectation.
       <br>
+      <br>
       Destiné principalement aux étudiants, jeunes diplômés, ou chercheurs d’emploi, de 18 à 28 ans, le Volontariat International est une expérience professionnelle enrichissante, véritable tremplin pour une carrière internationale.
     </div>
     <br>
 
     <h4>2.	Mon contrat V.I</h4>
-    Pour ma part j’ai effectué mon V.I au sein de <%= @document.company %> pendant <b><%= @duration %> mois</b> entre <%= "#{@document.start_date.strftime("%B")} #{@document.start_date.year} et #{@document.end_date.strftime("%B")} #{@document.end_date.year}" %> en tant que <%= @document.work_type %> : « <%= @document.work %> ».
+    Pour ma part j’ai effectué mon V.I au sein de <%= @document.company %> pendant <b><%= @duration %> mois</b> entre le <%= "#{I18n.with_locale("fr") { I18n.l(@document.start_date, format: "%e %B %Y")}} et le #{I18n.with_locale("fr") { I18n.l(@document.end_date, format: "%e %B %Y")}}" %> en tant que <%= @document.work_type %> : « <%= @document.work %> ».
     <br>
-    Mon contrat V.I a donc pris fin au <b><%= (@document.end_date + 1).strftime("%e %B %Y") %> </b>(cf Certificat d’accomplissement de volontariat civil à l’étranger).
+    <br>
+    Mon contrat V.I a donc pris fin au <b><%= I18n.with_locale("fr") { I18n.l(@document.end_date, format: "%e %B %Y")} %> </b>(cf Certificat d’accomplissement de volontariat civil à l’étranger).
 
     <br><br>
     <h4>3.	Le V.I reconnu comme service civique</h4>
-    L’article <b><a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000021954325&categorieLien=id#:~:text=%2DI.,d'une%20personne%20morale%20agr%C3%A9%C3%A9e" target="_blank">L.120-1 de la loi n° 2010-241 du 10 mars 2010</a></b> précise que le Volontariat International est reconnu comme un <b>service civique</b> :
+    L’article <b><a class="mr-1" href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000021954325&categorieLien=id#:~:text=%2DI.,d'une%20personne%20morale%20agr%C3%A9%C3%A9e" target="_blank">L.120-1 de la loi n° 2010-241 du 10 mars 2010</a></b> précise que le Volontariat International est reconnu comme un <b>service civique</b> :
+    <br>
     <br>
     <i>« Le service civique peut également prendre les formes suivantes : […]
     <br>
-     « 2o Le volontariat international en administration et le volontariat international en entreprise mentionnés au chapitre II du titre II du présent livre, le volontariat de solidarité internationale régi par la loi no 2005-159 du 23 février 2005 relative au contrat de volontariat de solidarité internationale ou le service volontaire européen défini par la décision no 1031/2000/CE du Parlement européen et du Conseil, du 13 avril 2000, établissant le programme d’action communautaire “Jeunesse” et par la décision no 1719/2006/CE du Parlement européen et du Conseil, du 15 novembre 2006, établissant le programme “Jeunesse en action” pour la période 2007-2013. »</i>
+     2o Le volontariat international en administration et le volontariat international en entreprise mentionnés au chapitre II du titre II du présent livre, le volontariat de solidarité internationale régi par la loi no 2005-159 du 23 février 2005 relative au contrat de volontariat de solidarité internationale ou le service volontaire européen défini par la décision no 1031/2000/CE du Parlement européen et du Conseil, du 13 avril 2000, établissant le programme d’action communautaire “Jeunesse” et par la décision no 1719/2006/CE du Parlement européen et du Conseil, du 15 novembre 2006, établissant le programme “Jeunesse en action” pour la période 2007-2013. »</i>
 
     <br><br>
     <h4>4.	Le versement des droits à indemnisation antérieurement acquis</h4>
     Le service civique <b>permet de « geler »</b> les droits au chômage durant la durée du V.I quand bien même celui-ci fait suite à une rupture de contrat de travail.
-    <br>Le Titre 1, chapitre 2, article 7 du <b><a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038829574&categorieLien=id" target="_blank">Décret n° 2019-797 du 26 juillet 2019 relatif au régime d'assurance chômage</b></a> précise que :
+    <br><br>Le Titre 1, chapitre 2, article 7 du <b><a class="ml-1" href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038829574&categorieLien=id" target="_blank">Décret n° 2019-797 du 26 juillet 2019 relatif au régime d'assurance chômage</b></a> précise que :
     <br>
-    <i>« La période de douze mois est allongée des périodes durant lesquelles ont été accomplies des obligations contractées à l'occasion du service national, en application des <a href= "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071335&idArticle=LEGIARTI000006555907&dateTexte=&categorieLien=cid" target="_blank">  premiers et deuxièmes alinéas de l'article L. 111-2 du code du service national</a>, et de la durée des missions accomplies dans le cadre d'un ou plusieurs contrats de service civique, dans ses différentes formes possibles, dans les conditions prévues à l'article <a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071335&idArticle=LEGIARTI000021956514&dateTexte=&categorieLien=cid"> L. 120-1 du même code ».</a></i><br>
+    <br>
+    <i>« La période de douze mois est allongée des périodes durant lesquelles ont été accomplies des obligations contractées à l'occasion du service national, en application des <a href= "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071335&idArticle=LEGIARTI000006555907&dateTexte=&categorieLien=cid" target="_blank">  premiers et deuxièmes alinéas de l'article L. 111-2 du code du service national</a>, et de la durée des missions accomplies dans le cadre d'un ou plusieurs contrats de service civique, dans ses différentes formes possibles, dans les conditions prévues à l'article <a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071335&idArticle=LEGIARTI000021956514&dateTexte=&categorieLien=cid" target="_blank"> L. 120-1 du même code ».</a></i>
+    <br>
+    <br>
     Le versement de mes droits à indemnisation antérieurement acquis à mon V.I, est suspendu pendant la durée de la mission et reprend au terme de celle-ci. La mission n’a pas d’impact sur le montant et la durée des allocations chômage.
     
     <br><br>
@@ -49,32 +57,49 @@
     <% if @unemployment_days_remaining %>
       <h4>5.   Réactivation de l'indemnisation en cours</h4>
 
-      Avant le commencement de ce V.I, j'avais pu bénéficier d'indemnités liées au chomage sur une durée de <%= @unemployment_days_paid %> jours.<br>
+      Avant le commencement de ce V.I, j'avais pu bénéficier d'indemnités liées au chomage sur une durée de <b><%= @unemployment_days_paid %> jours</b>.<br>
 
-      Lors du l'ouverture de ces droits, il m'avait été précisé que la durée totale de cette indemnité s'étalait sur une période <%= @document.info.days_unemployment %> jours, après calcul, il me reste donc <%= @unemployment_days_remaining %> jours sur cette même indemnité.<br>
+      Lors du l'ouverture de ces droits, il m'avait été précisé que la durée totale de cette indemnité s'étalait sur une période <%= @document.info.days_unemployment %> jours, après calcul, il me reste donc <b><%= @unemployment_days_remaining %> jours</b> sur cette même indemnité.<br>
 
     <% else %>
       
       <h4>5.	Démission légitime pour conclure un V.I</h4>
-      Ma démission de mon ancien contrat de travail pour effectuer ce V.I est considérée comme <b>légitime</b> (et donc ouvrant des droits au chômage) car il est indiqué au Titre 1, chapitre 2, article 2 du <b>Décret n° 2019-797 du 26 juillet 2019 relatif au régime d'assurance chômage</b> :<br>
-
-      <i>« Sont assimilés à des salariés involontairement privés d'emploi au sens de l'article<a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000006903823&dateTexte=&categorieLien=cid" target= _blank>L. 5422-1 du code du travail</a>, et ont donc également droit à l'allocation d'aide au retour à l'emploi, les salariés dont la cessation du contrat de travail résulte d'un des cas de démission légitime suivants : […]
+      Ma démission de mon ancien contrat de travail pour effectuer ce V.I est considérée comme <b>légitime</b> (et donc ouvrant des droits au chômage) car il est indiqué au Titre 1, chapitre 2, article 2 du <b>Décret n° 2019-797 du 26 juillet 2019 relatif au régime d'assurance chômage</b> :
+      <br>
+      <br>
+      <i>« Sont assimilés à des salariés involontairement privés d'emploi au sens de l'article <a class="ml-1" href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000006903823&dateTexte=&categorieLien=cid" target= _blank>L. 5422-1 du code du travail</a>, et ont donc également droit à l'allocation d'aide au retour à l'emploi, les salariés dont la cessation du contrat de travail résulte d'un des cas de démission légitime suivants : […]
 
       <br>
       o. La démission du salarié qui quitte son emploi pour conclure un contrat de service civique au sens de l'article <a href="https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071335&idArticle=LEGIARTI000021956514&dateTexte=&categorieLien=cid" target="_blank">L. 120-1 du code du service national</a>. »
       </i>
 
       <br>
+      <br>
       L’article L.120-10 de la <b>loi n°2010-241 du 10 mars 2010 </b>précise aussi que :
+      <br>
       <br>
       <i> « La rupture de son contrat de travail, à l’initiative du salarié, aux fins de souscrire un contrat de service civique, ne peut avoir pour effet de le priver de ses droits à l’assurance chômage à l’issue de son service civique ».</i>
 
       <br><br>
       <h4>6.	Le détail de mes droits à indemnisation acquis antérieurement à ce V.I</h4>
       <div>
-        Entre le <b><%= "#{@document.old_start_date.strftime("%e %B %Y")} et le #{@document.old_end_date.strftime("%e %B %Y")}" %></b>, j’ai travaillé en tant que <%= @document.old_work %> au sein de <%= @document.old_company %>. (cf. attestation d’employeur destinée à Pôle emploi).
+        Entre le <b><%= "#{I18n.with_locale("fr") { I18n.l(@document.old_start_date, format: "%e %B %Y")}} et le #{I18n.with_locale("fr") { I18n.l(@document.old_end_date, format: "%e %B %Y")}}" %></b>, j’ai travaillé en tant que <%= @document.old_work %> au sein de <%= @document.old_company %>. (cf. attestation d’employeur destinée à Pôle emploi).
         <br>
-        J’ai donc cotisé au chômage sur cette période (<%= "#{@document.old_start_date.year}-#{@document.old_end_date.year}" %>) pour laquelle je peux, aujourd’hui, recevoir des allocations chômages.
+        <br>
+        <div class="mb-1">
+          J’ai donc cotisé au chômage sur <%= @info.jobs.length > 0 ? "les périodes" : "la période"%> :
+        </div>
+        <ul>
+            <li><%= @document.old_start_date %> - <%= @document.old_end_date %> au sein de l'entreprise <%= @document.old_company %> en tant que <%= @document.old_work %></li>
+          <% if @info.jobs.length > 0 %>
+            <% @info.jobs.each do |job| %>
+              <div>
+                <li><%= job.start_at %> - <%= job.end_at %> au sein de l'entreprise <%= job.company %> en tant que <%= job.work %></li>
+              </div>
+            <% end %>
+          <% end %>
+        </ul>
+        <%= @info.jobs.length > 0 ? "Périodes pour lesquelles" : "Période pour laquelle"%> je peux, aujourd'hui percevoir des allocations chômage
       </div>
     <% end %>
 

--- a/app/views/documents/show.pdf.erb
+++ b/app/views/documents/show.pdf.erb
@@ -99,7 +99,9 @@
             <% end %>
           <% end %>
         </ul>
-        <%= @info.jobs.length > 0 ? "Périodes pour lesquelles" : "Période pour laquelle"%> je peux, aujourd'hui percevoir des allocations chômage
+        <%= @info.jobs.length > 0 ? "Périodes pour lesquelles" : "Période pour laquelle"%> je peux, aujourd'hui percevoir des allocations chômage.
+        <br>
+        Après calcul, cela devrait représenter <%= @days_worked %> jours.
       </div>
     <% end %>
 


### PR DESCRIPTION
Nouvelle branche qui regroupe toutes les conditions concernant les dates :
 1) Reajustage de la date de début d'un job si trop ancienne ( supérieur au 24 moins autorisés)
 2) Suppression d'un job si la date de fin est antérieur aux 24 mois (non prise en compte dans le calcul du chomage)
 3) Calcul du délai entre la date du jour et la date de fin de VI
 4) Validation -> Impossible de renseigner des jobs qui se chevauchent en terme de dates