### PR TITLE
Delete chomage question about old job + add error page redirection wh…

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,7 +3,7 @@ class DocumentsController < ApplicationController
   def show
     @document = Document.find(params[:id])
     @info = Info.find(params[:info_id])
-    @days_worked = (@document.old_end_date - @document.verify_start_date).to_i
+    @days_worked = (@document.old_end_date - @document.verify_start_date).to_i unless @document.old_end_date.nil?
     if @document.start_unemployment_at
       unemployment_calc(@document.start_date, @document.start_unemployment_at)
     elsif @document.info.jobs.present?
@@ -11,7 +11,6 @@ class DocumentsController < ApplicationController
       @document.recalculate_jobs
     end
     @duration = (@document.end_date - @document.start_date).to_i / 30
-    raise
     respond_to do |format|
       format.html
       format.pdf do
@@ -44,13 +43,18 @@ class DocumentsController < ApplicationController
   def create
     @document = Document.new(params_document)
     @info = Info.find(params[:info_id])
+    @info.unemployment == "Oui" ? @document.unemployment = true : @document.unemployment = false
     @job = Job.new
     @document.info_id = params[:info_id]
-    @days_worked = (@document.old_end_date - @document.verify_start_date).to_i
+    @days_worked = (@document.old_end_date - @document.verify_start_date).to_i unless @document.old_end_date.nil?
     @days_worked += @document.days_worked_other_jobs_calc if @document.info.jobs.present?
+    unemployment_calc(@document.start_date, @document.start_unemployment_at) if @document.start_unemployment_at
     if @document.save
+      # Si les jours restant sont négatifs, redirige vers la page d'erreur
+      if @unemployment_days_remaining.negative?
+        redirect_to error_path(key: :not_anymore)
       # Si la personne a cumulé moins de 180 jours de travail sur les 2 dernières années elle n'a pas le droit au chômage
-      if @days_worked >= 180
+      elsif @days_worked.nil? || @days_worked >= 180
         redirect_to info_document_path(@info, @document, format: :pdf)
       else
         redirect_to error_path(key: :not_enough)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -7,18 +7,23 @@ class Document < ApplicationRecord
   validates :work_type, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
-  validates :old_company, presence: true
-  validates :old_work, presence: true
-  validates :old_start_date, presence: true
-  validates :old_end_date, presence: true
+  validates :old_company, presence: true, unless: :unemployment?
+  validates :old_work, presence: true, unless: :unemployment?
+  validates :old_start_date, presence: true, unless: :unemployment?
+  validates :old_end_date, presence: true, unless: :unemployment?
+  validates :unemployment, presence: true
   validate :start_date_cannot_be_in_the_future
   validate :end_date_cannot_be_before_start_date
   validate :old_end_date_cannot_be_after_start_date
   validate :end_date_cannot_be_too_big
   validate :start_unemployment_at_cannot_be_after_start_date
-  validate :start_unemployment_at_cannot_be_before_old_end_date
+  # validate :start_unemployment_at_cannot_be_before_old_end_date, if: :unemployment?
   validate :jobs_validation
   belongs_to :info
+
+  def unemployment?
+    unemployment == true
+  end
 
   def start_date_cannot_be_in_the_future
     if start_date.present? && start_date > Date.today 
@@ -45,25 +50,25 @@ class Document < ApplicationRecord
   end
 
   def old_end_date_cannot_be_after_start_date
-    if old_end_date.present? && start_date.present? && old_end_date >= start_date
+    if old_end_date.present? && start_date.present? && old_end_date > start_date
       errors.add(:old_end_date, "ne peut pas être après la date de début de V.I")
     end
-    if old_start_date.present? && start_date.present? && old_start_date >= start_date
+    if old_start_date.present? && start_date.present? && old_start_date > start_date
       errors.add(:old_start_date, "ne peut pas être après la date de début de V.I")
     end
   end
 
   def start_unemployment_at_cannot_be_after_start_date
     if start_unemployment_at.present? && start_unemployment_at >= start_date
-      errors.add(:start_unemployment_at, "ne peut pas être après la date de début de V.I")
+      errors.add(:start_unemployment_at, "ne peut pas être égale ou après la date de début de V.I")
     end
   end
 
-  def start_unemployment_at_cannot_be_before_old_end_date
-    if start_unemployment_at.present? && start_unemployment_at < old_end_date
-      errors.add(:start_unemployment_at, "ne peut pas être avant la date de fin de dernier emploi")
-    end
-  end
+  # def start_unemployment_at_cannot_be_before_old_end_date
+  #   if start_unemployment_at.present? && start_unemployment_at < old_end_date
+  #     errors.add(:start_unemployment_at, "ne peut pas être avant la date de fin de dernier emploi")
+  #   end
+  # end
 
   def end_date_cannot_be_too_big
     if end_date.present? && old_end_date.present? && end_date - old_end_date > 1080
@@ -83,7 +88,7 @@ class Document < ApplicationRecord
   end
 
   def verify_start_date
-    if old_start_date < start_date.advance(days: -730 + self.latency)
+    if old_start_date.present? && old_start_date < start_date.advance(days: -730 + self.latency)
       start_date.advance(days: -730 + self.latency)
     else
       old_start_date

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -12,6 +12,7 @@ class Document < ApplicationRecord
   validates :old_start_date, presence: true, unless: :unemployment?
   validates :old_end_date, presence: true, unless: :unemployment?
   validates :unemployment, presence: true
+  validates :start_unemployment_at, presence: true, if: :unemployment?
   validate :start_date_cannot_be_in_the_future
   validate :end_date_cannot_be_before_start_date
   validate :old_end_date_cannot_be_after_start_date

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -9,12 +9,13 @@
     <%= f.input :work_type, collection: Document::WORK_TYPE, label: "Type de contrat" %>
     <%= f.input :start_date, label: "Date à laquelle tu as commencé ton V.I", as: :string, required: false, input_html: {class: "datepicker"} %>
     <%= f.input :end_date, label: "Date à laquelle tu as terminé ton V.I", as: :string, required: false, input_html: {class: "datepicker"} %>
-    <%= f.input :old_company, label: "Ton dernier employeur avant ton V.I" %>
-    <%= f.input :old_work, label: "Intitulé de ton ancien poste" %>
-    <%= f.input :old_start_date, label: "Date de début de ton ancien poste", as: :string, required: false, input_html: {class: "datepicker"} %>
-    <%= f.input :old_end_date, label: "Date de fin de ton ancien poste", as: :string, required: false, input_html: {class: "datepicker"}%>
-    <% if @info.unemployment == "Oui" %>
-      <%= f.input :start_unemployment_at, label: "Date de début de ton chomage", as: :string, required: false, input_html: {class: "datepicker"}%>
+    <% if @info.unemployment == "Non" %>
+      <%= f.input :old_company, label: "Ton dernier employeur avant ton V.I" %>
+      <%= f.input :old_work, label: "Intitulé de ton ancien poste" %>
+      <%= f.input :old_start_date, label: "Date de début de ton ancien poste", as: :string, required: false, input_html: {class: "datepicker"} %>
+      <%= f.input :old_end_date, label: "Date de fin de ton ancien poste", as: :string, required: false, input_html: {class: "datepicker"}%>
+    <% else %>
+      <%= f.input :start_unemployment_at, label: "Quand as-tu commencé à percevoir tes allocations chômage ?", as: :string, required: false, input_html: {class: "datepicker"}%>
     <% end %>
     <div class="text-center"> Si besoin, tu peux ajouter un ou plusieurs emplois (CDD, intérim ..) en plus de ton dernier emploi </div>
     <div class="text-center">

--- a/app/views/infos/error.html.erb
+++ b/app/views/infos/error.html.erb
@@ -1,8 +1,20 @@
  <div class="error-container d-flex flex-wrap justify-content-center align-items-center flex-column">
-    <h1 class="error-text">Eh non, désolé, tu n'as pas le droit au chomdu !</h1>
+    <h1 class="error-text">Eh non, désolé, tu n'as pas le droit au chômage !</h1>
     <br>
-    <% if params[:key] %>
-      <h3 class="error-text">Tu n'as pas cumulé assez de jours de travail avant ton V.I (mais c'est bien tenté) !</h1>
+    <% if params[:key] == "not_enough" %>
+      <h3 class="error-text">
+        Tu n'as pas cumulé assez de jours de travail avant ton V.I (mais c'est bien tenté) !
+        <br>
+        Depuis le <a class="links" href="https://www.service-public.fr/particuliers/vosdroits/F14860" target="_blank">1er Novembre 2019</a> il faut avoir travailler 6 mois sur les 24 derniers mois (avant ton V.I) pour bénéficier du chômage
+      </h3>
+    <% elsif params[:key] == "not_anymore" %>
+      <h3 class="error-text">
+        Tu as déjà épuisé tous tes droits au chômage avant ton V.I (mais c'est bien tenté) !
+      </h3>
+    <% else %>
+      <h3 class="error-text">
+        Depuis le <a class="links" href="https://www.service-public.fr/particuliers/vosdroits/F14860" target="_blank">1er Novembre 2019</a> il faut avoir travailler 6 mois sur les 24 derniers mois (avant ton V.I) pour bénéficier du chômage
+      </h3>
     <% end %>
   </div>
   <div class="error-image">

--- a/db/migrate/20200909152949_create_documents.rb
+++ b/db/migrate/20200909152949_create_documents.rb
@@ -13,6 +13,7 @@ class CreateDocuments < ActiveRecord::Migration[6.0]
       t.string :old_work
       t.string :old_company
       t.date :start_unemployment_at
+      t.boolean :unemployment
       t.references :info, null: false, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_195350) do
     t.string "old_work"
     t.string "old_company"
     t.date "start_unemployment_at"
+    t.boolean "unemployment"
     t.bigint "info_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
Principales modifs : 

- Supprimer les questions sur l'ancien job si la personne touchait le chômage avant son V.I (on reprend juste les droits qu'il avait déjà acquis)
- Ajouter une page d'erreur si la personne a consommé tous ses droits au chômage